### PR TITLE
Document rationale for FAISS retrieval stack

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# Repository Guidelines
+
+## Process Improvements
+- Always review existing modules in `app/` to understand domain-specific utilities before introducing new helpers.
+- Prefer reusing shared services located in `app/services/` and shared utilities in `app/utils/` when implementing new features.
+- Document any new environment variables in `README.md` and reflect them in configuration loaders under `app/config.py`.
+
+## Systemic Adjustments
+- When touching retrieval or ingestion logic, ensure that both `app/retrieval.py` and `app/ingest.py` continue to respect the same interface contracts exposed through the service layer.
+- Use structured logging utilities defined in `app/logging_config.py` for new background jobs or CLI scripts.
+- Keep schema updates synchronized between `app/schemas.py` and any corresponding data store adapters within `app/store/`.
+
+## Testing & QA
+- Run the relevant unit or integration tests prior to committing changes; add new tests under `app/tests/` when new functionality is introduced.
+- Validate prompts located in `app/prompting.py` with sample conversations to confirm expected behavior.

--- a/README.md
+++ b/README.md
@@ -150,3 +150,25 @@ The MVP targets:
 Future enhancements include migrating to Qdrant, integrating cross-encoder
 reranking, function-calling outputs, advanced PII detection (spaCy/Presidio),
 and OCR support for scanned PDFs.
+
+## Why sentence-transformers + FAISS today?
+
+The current stack intentionally favors the lightweight combination of
+**sentence-transformers** and a local **FAISS** index because it:
+
+- Keeps ingestion and retrieval entirely offline/air-gapped, matching the
+  compliance expectations for handling sensitive administrative documents.
+- Ships with zero external services to operate, making it cheap to run on a
+  single machine (CPU-only if necessary) and easy to containerize for pilots.
+- Provides deterministic cosine similarity search with excellent recall for the
+  legal-sized corpus we target (<50k fragments) while staying within a tiny
+  memory footprint.
+
+Alternatives absolutely exist—vector databases such as **Qdrant**, **Milvus**,
+or **Weaviate** would offer managed storage, horizontal scaling, and hybrid
+filtering. Likewise, upgrading to cross-encoder reranking models or larger
+embedding models (e.g., `text-embedding-3-large`) could boost quality at the
+expense of latency and cost. For the MVP we prioritised operability and
+on-premise friendliness, but the ingestion metadata schema and retrieval
+service have been designed so we can swap in those heavier options when the
+corpus, traffic, or accuracy requirements demand it.

--- a/app/retrieval.py
+++ b/app/retrieval.py
@@ -1,4 +1,11 @@
-"""Retrieval layer using FAISS and sentence-transformers."""
+"""Retrieval layer using FAISS and sentence-transformers.
+
+The MVP favors this pairing because it is fully self-hostable, fast on CPU-only
+hardware, and easy to reason about for a corpus that comfortably fits into a
+single FAISS `IndexFlatIP`. The surrounding plumbing keeps the metadata schema
+and scoring hooks generic so we can migrate to a managed vector database or
+plug in heavier cross-encoder rerankers when scale demands it.
+"""
 from __future__ import annotations
 
 import json


### PR DESCRIPTION
## Summary
- expand the retrieval module documentation to explain the current FAISS + sentence-transformers choice and how it can evolve
- add README guidance on why the MVP uses this stack today and what alternatives could replace it later

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918486a33b483309b99621ffc47ae29)